### PR TITLE
Bump version to 0.5.0 and add `eachSplit` helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scholars-embed-utilities",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Embed utilities for Scholars Discovery UI clients",
   "keywords": [],
   "license": "MIT",

--- a/src/utilities/template.utility.ts
+++ b/src/utilities/template.utility.ts
@@ -263,6 +263,20 @@ const initializeTemplateHelpers = (mapping: any = {}) => {
         return out;
     });
 
+    Handlebars.registerHelper('eachSplit', function (value, delimeter, options) {
+        let out = '';
+        if (value) {
+            value = value.toString();
+            const parts = value.split(delimeter);
+            for (const i in parts) {
+                if (parts.hasOwnProperty(i)) {
+                    out += options.fn(parts[i].trim());
+                }
+            }
+        }
+        return out;
+    });
+
     Handlebars.registerHelper('tags', (taggable, options) => {
         const tags = getTags(taggable);
         let out = '';


### PR DESCRIPTION
 - Relocated the 'eachSplit' handlebar method from 'scholars-discovery' repository to this repository.
 - The 'eachSplit' helper to split the 'streetAddress' property using semicolons as delimiters and render each part on a new line.
 
 This change partly resolves Issue: https://github.com/TAMULib/scholars-angular/issues/480